### PR TITLE
Add message when no results are present

### DIFF
--- a/app/views/addresses/index.html.erb
+++ b/app/views/addresses/index.html.erb
@@ -30,20 +30,28 @@
 
 <% if @addresses %>
 
-  <h1>Results:</h1>
+  <% if @addresses.count == 0 %>
+    <div class="alert alert-warning" role="alert">
+      <p>Sorry, there were no results for your query.</p>
+    </div>
+  <% else %>
 
-  <div id="map"></div>
+    <h1>Results:</h1>
 
-  <ul>
-  <% @addresses.each do |address| %>
+    <div id="map"></div>
 
-    <li data-latlng="<%= address.postcode.lat_lng.to_a.join(",") %>"><%= link_to address.full_address, address %></li>
+    <ul>
+    <% @addresses.each do |address| %>
+
+      <li data-latlng="<%= address.postcode.lat_lng.to_a.join(",") %>"><%= link_to address.full_address, address %></li>
+
+    <% end %>
+    </ul>
+
+    <%= paginate @addresses %>
+
+    <%= alternate_link_buttons(class: 'btn btn-sm btn-primary') %>
 
   <% end %>
-  </ul>
-
-  <%= paginate @addresses %>
-
-  <%= alternate_link_buttons(class: 'btn btn-sm btn-primary') %>
 
 <% end %>

--- a/spec/controllers/addresses_spec.rb
+++ b/spec/controllers/addresses_spec.rb
@@ -69,6 +69,12 @@ RSpec.describe AddressesController, :type => :controller do
 
       expect(json['addresses'].first['url']).to match /http:\/\/test\.host\/addresses\/[0-9a-z]+/i
     end
+
+    it 'shows an message when there are no addresses found for a query' do
+      get :index, town: "Nowheretown"
+
+      expect(response.body).to match(/Sorry, there were no results for your query/)
+    end
   end
 
   describe 'GET #show' do


### PR DESCRIPTION
Adds a friendly message to let the user know there are no results if their query doesn't match anything
