### PR TITLE
Added ODI Certificate badge

### DIFF
--- a/app/views/static/data.html
+++ b/app/views/static/data.html
@@ -33,6 +33,8 @@ layout: notitle
     </a>
   </p>
 
+  <script src='https://certificates.theodi.org/datasets/22687/certificate/badge.js'></script>
+
   <p>
     You will need a BitTorrent client in order to download the data. We recommend:
     <ul>


### PR DESCRIPTION
@peterkwells this pull request adds to the "Get the data" page ODI's official code snippet to display the ODI certificate badge, just after where we say "Published by Open Addresses Ltd.". 
