### PR TITLE
Use href instead of data-toggle

### DIFF
--- a/app/views/static/_includes/_submission_form.html
+++ b/app/views/static/_includes/_submission_form.html
@@ -26,7 +26,7 @@ var submitted=false;
   <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
       <button type="submit" class="btn btn-primary">Submit this address</button>
-      <a data-toggle="collapse" data-target="#submission-guidelines" href="#"><small>Read the submission guidelines</small></a>
+      <a data-toggle="collapse" href="#submission-guidelines"><small>Read the submission guidelines</small></a>
     </div>
   </div>
   <div id="submission-guidelines" class="form-group collapse">


### PR DESCRIPTION
Adding `href` and `data-target` meant the browser followed the href. The proper way to do it is to put the target in `href`