### PR TITLE
Add viewport width and scale meta tag

### DIFF
--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -1,5 +1,6 @@
 <head>
   <title>Open Addresses UK - Alpha <%= (@metadata ? ": #{@metadata['title']}" : nil) %></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= stylesheet_link_tag 'https://api.tiles.mapbox.com/mapbox.js/v2.1.4/mapbox.css', media: 'all', 'data-turbolinks-track' => true %>
   <%= stylesheet_link_tag '//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css' %>


### PR DESCRIPTION
The site previously didn't work well on mobile.  Adding the initial width meta tag allows the CSS media queries to kick.  It's looking _alright_ on mobile, but I expect the address filling out process could be thought about a bit better (no specific suggestions though!)